### PR TITLE
Upgrade to modern PHP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/*
 *.lock
 index.php
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -45,11 +45,16 @@ $voucher = new Voucher(['code' => 'ALAN-COLE-CODE', 'claimed_by' => '', 'claimed
 print $voucher; // "ALAN-COLE-CODE"
 ```
 
-Any value passed on voucher creation can be get and set using `get()` and `set()` on the voucher.
+Any value passed on voucher creation can be get and set using magic getters and setters
 
 ```php
-$voucher->set('owner', 'Alan');
-echo $voucher->get('owner'); // Alan
+$voucher->setOwner('alan')
+echo $voucher->getOwner() // Alan
+
+$voucher->setIsClaimed(true);
+if($voucher->getIsClaimed() === true) {
+    // Sorry dave I can't do that.
+}
 ```
 
 ### Model

--- a/composer.json
+++ b/composer.json
@@ -6,5 +6,9 @@
         "psr-4": {
             "Vouchers\\": "src/Vouchers"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.0",
+        "phpstan/phpstan": "^1.10"
     }
 }

--- a/src/Vouchers/Bag.php
+++ b/src/Vouchers/Bag.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Vouchers;
 
@@ -46,7 +46,7 @@ class Bag extends Bag\Collection
      *
      * @return void
      */
-    public function fill($number = 0)
+    public function fill($number = 0) :void
     {
         for ($i = 0; $i < $number; $i++) {
             $this->add(new Voucher());
@@ -77,7 +77,7 @@ class Bag extends Bag\Collection
      *
      * @return Voucher $voucher
      */
-    public function pickWithCallback(callable $callback)
+    public function pickWithCallback(callable $callback) :Voucher
     {
         foreach ($this->values as $voucher) {
             if ($callback($voucher)) {
@@ -96,7 +96,7 @@ class Bag extends Bag\Collection
      *
      * @return void
      */
-    public function map(array $data, callable $callback)
+    public function map(array $data, callable $callback) :void
     {
         foreach ($data as $item) {
             $result = $callback($item);
@@ -114,7 +114,7 @@ class Bag extends Bag\Collection
      *
      * @return bool
      */
-    public function pickValid()
+    public function pickValid() :Voucher
     {
         $voucher = null;
         foreach ($this->values as $value) {
@@ -144,7 +144,7 @@ class Bag extends Bag\Collection
      *
      * @return bool
      */
-    public function validate($code)
+    public function validate($code) :bool
     {
         foreach ($this->validators as $rule) {
             $callback = $rule['callback'];
@@ -166,7 +166,7 @@ class Bag extends Bag\Collection
      *
      * @return void
      */
-    public function validator(callable $callback, $message = self::VALIDATION_MESSAGE)
+    public function validator(callable $callback, $message = self::VALIDATION_MESSAGE) :void
     {
         $rule = [
             'message'  => $message,
@@ -182,7 +182,7 @@ class Bag extends Bag\Collection
      *
      * @return void
      */
-    public function add(Voucher $voucher)
+    public function add(Voucher $voucher) :void
     {
         if ($this->model) {
             $this->model->validate($voucher->toArray());
@@ -196,9 +196,9 @@ class Bag extends Bag\Collection
      *
      * @param string $code
      *
-     * @return string|Voucher
+     * @return bool|Voucher
      */
-    public function find($code)
+    public function find($code) :bool|Voucher
     {
         foreach ($this->values as $key => $voucher) {
             if ($code == (string) $voucher) {

--- a/src/Vouchers/Bag/Collection.php
+++ b/src/Vouchers/Bag/Collection.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Vouchers\Bag;
 
@@ -71,7 +71,7 @@ class Collection implements \Iterator
      *
      * @return array
      */
-    public function toArray()
+    public function toArray() :array
     {
         $collection = [];
         foreach ($this->values as $value) {

--- a/src/Vouchers/Bag/Collection.php
+++ b/src/Vouchers/Bag/Collection.php
@@ -16,7 +16,7 @@ class Collection implements \Iterator
      *
      * @return mixed
      */
-    public function current()
+    public function current() :mixed
     {
         return current($this->values);
     }
@@ -24,7 +24,7 @@ class Collection implements \Iterator
     /**
      * Returns the key of our current.
      */
-    public function key()
+    public function key() :mixed
     {
         return key($this->values);
     }
@@ -32,7 +32,7 @@ class Collection implements \Iterator
     /**
      * Moves array to next array item.
      */
-    public function next()
+    public function next() :void
     {
         return next($this->values);
     }
@@ -40,7 +40,7 @@ class Collection implements \Iterator
     /**
      * Reset the array.
      */
-    public function rewind()
+    public function rewind() :void
     {
         return reset($this->values);
     }
@@ -50,7 +50,7 @@ class Collection implements \Iterator
      *
      * @return int
      */
-    public function count()
+    public function count() :int
     {
         return count($this->values);
     }
@@ -59,7 +59,7 @@ class Collection implements \Iterator
      * Make sure the key is a real one
      * or loops will last forever.
      */
-    public function valid()
+    public function valid() :bool
     {
         $key = key($this->values);
 

--- a/src/Vouchers/Exceptions/ImmutableData.php
+++ b/src/Vouchers/Exceptions/ImmutableData.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Vouchers\Exceptions;
 

--- a/src/Vouchers/Exceptions/NoValidVouchers.php
+++ b/src/Vouchers/Exceptions/NoValidVouchers.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Vouchers\Exceptions;
 

--- a/src/Vouchers/Exceptions/ValidationCallbackFail.php
+++ b/src/Vouchers/Exceptions/ValidationCallbackFail.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Vouchers\Exceptions;
 

--- a/src/Vouchers/Exceptions/VoucherCodeInvalid.php
+++ b/src/Vouchers/Exceptions/VoucherCodeInvalid.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Vouchers\Exceptions;
 

--- a/src/Vouchers/Exceptions/VoucherValidationFailed.php
+++ b/src/Vouchers/Exceptions/VoucherValidationFailed.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Vouchers\Exceptions;
 

--- a/src/Vouchers/Voucher/Code/Generator.php
+++ b/src/Vouchers/Voucher/Code/Generator.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Vouchers\Voucher\Code;
 
@@ -18,7 +18,7 @@ class Generator implements GeneratorInterface
      *
      * @return string
      */
-    public function part()
+    public function part() :string
     {
         return bin2hex(openssl_random_pseudo_bytes(2));
     }
@@ -28,7 +28,7 @@ class Generator implements GeneratorInterface
      *
      * @return string
      */
-    public function generate()
+    public function generate() :string
     {
         return strtoupper(sprintf('%s-%s-%s-%s', $this->part(), $this->part(), $this->part(), $this->part()));
     }
@@ -40,7 +40,7 @@ class Generator implements GeneratorInterface
      *
      * @return bool
      */
-    public function validate($code)
+    public function validate(string $code) :bool
     {
         return (bool) preg_match($code, self::REGEX);
     }

--- a/src/Vouchers/Voucher/Code/GeneratorInterface.php
+++ b/src/Vouchers/Voucher/Code/GeneratorInterface.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Vouchers\Voucher\Code;
 
@@ -9,7 +9,7 @@ interface GeneratorInterface
      *
      * @return string
      */
-    public function generate();
+    public function generate() :string;
 
     /**
      * Validate a voucher code.
@@ -18,5 +18,5 @@ interface GeneratorInterface
      *
      * @return bool
      */
-    public function validate($code);
+    public function validate(string $code) :bool;
 }

--- a/src/Vouchers/Voucher/Model.php
+++ b/src/Vouchers/Voucher/Model.php
@@ -3,6 +3,7 @@
 namespace Vouchers\Voucher;
 
 use Vouchers\Voucher as V;
+use Vouchers\Voucher\Code\GeneratorInterface as Generator;
 
 class Model
 {
@@ -23,7 +24,7 @@ class Model
     /**
      * Custom generator?
      *
-     * @var class
+     * @var Generator
      */
     protected $generator;
 

--- a/tests/Vouchers/BagTest.php
+++ b/tests/Vouchers/BagTest.php
@@ -2,9 +2,9 @@
 
 namespace Vouchers\Tests;
 
-use PHPUnit_Framework_TestCase as PHPUnit;
+use PHPUnit\Framework\TestCase;
 
-class BagTest extends PHPUnit
+class BagTest extends TestCase
 {
     /**
      * Start a bag.
@@ -106,6 +106,7 @@ class BagTest extends PHPUnit
      */
     public function testCanFailToPickWithValidatorCallback()
     {
+        $this->expectException(\Vouchers\Exceptions\NoValidVouchers::class);
         $bag = new \Vouchers\Bag();
         $bag->fill(100);
 
@@ -147,6 +148,8 @@ class BagTest extends PHPUnit
         $bag->map($vouchers, function ($voucher) {
             return new \Vouchers\Voucher($voucher);
         });
+
+        $this->assertEquals($bag->count(), 4);
     }
 
     /**
@@ -157,6 +160,7 @@ class BagTest extends PHPUnit
      */
     public function testInvalidModelOnBag()
     {
+        $this->expectException(\Vouchers\Exceptions\VoucherValidationFailed::class);
         $model = new \Vouchers\Voucher\Model([
             'name' => [
                 'required'  => true,
@@ -232,6 +236,7 @@ class BagTest extends PHPUnit
      */
     public function testPickWithACallbackFails()
     {
+        $this->expectException(\Vouchers\Exceptions\NoValidVouchers::class);
         $bag = new \Vouchers\Bag();
         $voucher = new \Vouchers\Voucher([
             'code'  => 'MY-Test-code',

--- a/tests/Vouchers/BagTest.php
+++ b/tests/Vouchers/BagTest.php
@@ -223,7 +223,7 @@ class BagTest extends TestCase
         $bag->add($voucher);
 
         $test = $bag->pick(function ($voucher) {
-            return $voucher->get('owner') == 'tester';
+            return $voucher->getOwner() == 'tester';
         });
 
         $this->assertSame($test, $voucher);
@@ -245,7 +245,7 @@ class BagTest extends TestCase
         $bag->add($voucher);
 
         $test = $bag->pick(function ($voucher) {
-            return $voucher->get('owner') == 'not a tester';
+            return $voucher->getOwner() == 'not a tester';
         });
 
         $this->assertSame($test, $voucher);

--- a/tests/Vouchers/ModelTest.php
+++ b/tests/Vouchers/ModelTest.php
@@ -71,7 +71,7 @@ class ModelTest extends TestCase
         ]);
 
         $voucher = new \Vouchers\Voucher(['created' => '12/12/12'], $model);
-        $voucher->set('created', 'something else');
+        $voucher->setCreated('13/13/13');
     }
 
     /**
@@ -89,7 +89,7 @@ class ModelTest extends TestCase
         ]);
 
         $voucher = new \Vouchers\Voucher(['name' => 'Alan Cole', 'email' => 'me@alancole.io'], $model);
-        $this->assertSame($voucher->get('name'), 'Alan Cole');
+        $this->assertSame($voucher->getName(), 'Alan Cole');
     }
 
     /**

--- a/tests/Vouchers/ModelTest.php
+++ b/tests/Vouchers/ModelTest.php
@@ -4,9 +4,9 @@ namespace Vouchers\Tests;
 
 require 'lib/TestGenerator.php';
 
-use PHPUnit_Framework_TestCase as PHPUnit;
+use PHPUnit\Framework\TestCase;
 
-class ModelTest extends PHPUnit
+class ModelTest extends TestCase
 {
     /**
      * Test custom generator class.
@@ -30,6 +30,7 @@ class ModelTest extends PHPUnit
      */
     public function testCustomValidatorError()
     {
+        $this->expectException(\Vouchers\Exceptions\VoucherCodeInvalid::class);
         $model = new \Vouchers\Voucher\Model([
             'code' => [
                 'generator' => "\Vouchers\Tests\TestGenerator",
@@ -61,6 +62,7 @@ class ModelTest extends PHPUnit
      */
     public function testAddingImmutableData()
     {
+        $this->expectException(\Vouchers\Exceptions\ImmutableData::class);
         $model = new \Vouchers\Voucher\Model([
             'created' => [
                 'required'  => true,
@@ -97,6 +99,7 @@ class ModelTest extends PHPUnit
      */
     public function testDataValidationError()
     {
+        $this->expectException(\Vouchers\Exceptions\VoucherValidationFailed::class);
         $model = new \Vouchers\Voucher\Model([
             'name' => [
                 'required'  => true,

--- a/tests/Vouchers/VoucherTest.php
+++ b/tests/Vouchers/VoucherTest.php
@@ -37,8 +37,8 @@ class VoucherTest extends TestCase
     public function testDataGetterAndSetter()
     {
         $voucher = new \Vouchers\Voucher();
-        $voucher->set('used', false);
-        $this->assertFalse($voucher->get('used'));
+        $voucher->setUsed(false);
+        $this->assertFalse($voucher->getUsed());
     }
 
     /**
@@ -48,6 +48,6 @@ class VoucherTest extends TestCase
     {
         $this->expectException(\Vouchers\Exceptions\ImmutableData::class);
         $voucher = new \Vouchers\Voucher();
-        $voucher->set('code', 'Something Else');
+        $voucher->setCode('SOMETHING-ELSE');
     }
 }

--- a/tests/Vouchers/VoucherTest.php
+++ b/tests/Vouchers/VoucherTest.php
@@ -2,9 +2,9 @@
 
 namespace Vouchers\Tests;
 
-use PHPUnit_Framework_TestCase as PHPUnit;
+use PHPUnit\Framework\TestCase;
 
-class VoucherTest extends PHPUnit
+class VoucherTest extends TestCase
 {
     /**
      * Make a voucher.
@@ -21,7 +21,7 @@ class VoucherTest extends PHPUnit
     public function testCanMakeAVoucherAndGenerateCode()
     {
         $voucher = new \Vouchers\Voucher();
-        $this->assertRegExp("/[\w\d]{4}\-[\w\d]{4}\-[\w\d]{4}\-[\w\d]{4}/", (string) $voucher);
+        $this->assertMatchesRegularExpression("/[\w\d]{4}\-[\w\d]{4}\-[\w\d]{4}\-[\w\d]{4}/", (string) $voucher);
     }
 
     /**
@@ -46,6 +46,7 @@ class VoucherTest extends PHPUnit
      */
     public function testCodeIsImmutable()
     {
+        $this->expectException(\Vouchers\Exceptions\ImmutableData::class);
         $voucher = new \Vouchers\Voucher();
         $voucher->set('code', 'Something Else');
     }

--- a/tests/Vouchers/lib/TestGenerator.php
+++ b/tests/Vouchers/lib/TestGenerator.php
@@ -8,12 +8,12 @@ class TestGenerator implements Generator
 {
     const TEST_CODE = 'VOUCHER-TEST-CODE';
 
-    public function generate()
+    public function generate() :string
     {
         return self::TEST_CODE;
     }
 
-    public function validate($code)
+    public function validate($code) :bool
     {
         return $code == self::TEST_CODE;
     }


### PR DESCRIPTION
This is a pull request to modernize the code of this library, setting the minimm requirement at PHP8. With this PR we, 

- Upgrade to PHPUnit 10, and update the tests accordingly (new base class, deprecation of the `@expectedException` docblock.
- Added PHPStan to the code to enable static analysis. 
- Adds strict types and return types to our functions
- Add a new magic `__call` function to allow for magic getters and setters using `getOurValue()` or `setOurValue('thing')` operations to get and set data on our data array, where `OurValue` maps to `our_value` in the data array. 
- Update the README.